### PR TITLE
Rename urls on backend due to convention

### DIFF
--- a/Backend/microservices/authority/src/main/java/com/ms/authority/controller/UserController.java
+++ b/Backend/microservices/authority/src/main/java/com/ms/authority/controller/UserController.java
@@ -45,14 +45,9 @@ public class UserController {
         userService.confirmRegister(confirmRegisterData);
     }
 
-    @PostMapping("/{userId}/enable")
-    public void enableUser(@PathVariable int userId) {
-        userService.changeUserActive(userId, true);
-    }
-
-    @PostMapping("/{userId}/disable")
-    public void disableUser(@PathVariable int userId) {
-        userService.changeUserActive(userId, false);
+    @PostMapping("/{userId}/active/{newState}")
+    public void enableUser(@PathVariable("userId") int userId, @PathVariable("newState") boolean newState) {
+        userService.changeUserActive(userId, newState);
     }
 
     @GetMapping

--- a/Backend/microservices/connector/README.MD
+++ b/Backend/microservices/connector/README.MD
@@ -1,6 +1,6 @@
 > ### how to use Connector API:
-* without Eureka server - http://localhost:8080/api/searcher/
-* with Eureka server - name = connector, url for requests = /api/searcher/
+* without Eureka server - http://localhost:8080/searcher
+* with Eureka server - name = connector, url for requests = /searcher
 * use method POST with valid token in header and body with json like this:
 
 {

--- a/Backend/microservices/connector/src/main/java/com/ms/connector/controller/SearchQueryController.java
+++ b/Backend/microservices/connector/src/main/java/com/ms/connector/controller/SearchQueryController.java
@@ -11,7 +11,7 @@ import java.util.Set;
 
 
 @RestController
-@RequestMapping("/api/searcher/")
+@RequestMapping("/searcher")
 public class SearchQueryController {
 
     @PostMapping

--- a/Backend/microservices/connector/src/main/resources/application.yml
+++ b/Backend/microservices/connector/src/main/resources/application.yml
@@ -6,6 +6,12 @@ eureka:
   service-url:
   default-zone: http://localhost:8761/eureka
 
+routes:
+  microservices:
+    authority:
+      root: http://localhost:8090
+      jwks: ${routes.microservices.authority.root}/.well-known/jwks.json
+
 spring:
   application:
     name: connector
@@ -13,4 +19,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://localhost:8090/.well-known/jwks.json
+          jwk-set-uri: ${routes.microservices.authority.jwks}

--- a/Backend/microservices/data/README.MD
+++ b/Backend/microservices/data/README.MD
@@ -1,6 +1,6 @@
 > ### how to use DATA API:
-* without Eureka server - http://localhost:8081/api/data
-* with Eureka server - name = connector, url for requests = /api/data
+* without Eureka server - http://localhost:8081/schemas
+* with Eureka server - name = connector, url for requests = /schemas
 * use method GET
 
 

--- a/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
@@ -10,8 +10,7 @@ public class JWTSecurityConfigData extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests(authz -> authz
-                        .antMatchers(HttpMethod.GET, "/**").hasAuthority("SCOPE_user")
-                        .antMatchers(HttpMethod.POST,  "/api/data").hasAuthority("SCOPE_admin_schema")
+                        .antMatchers(HttpMethod.POST, "/schemes").hasAuthority("SCOPE_admin_schema")
                         .anyRequest().hasAuthority("SCOPE_user"))
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt());
     }

--- a/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
@@ -10,7 +10,7 @@ public class JWTSecurityConfigData extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests(authz -> authz
-                        .antMatchers(HttpMethod.POST, "/schemes").hasAuthority("SCOPE_admin_schema")
+                        .antMatchers(HttpMethod.POST, "/schemas").hasAuthority("SCOPE_admin_schema")
                         .anyRequest().hasAuthority("SCOPE_user"))
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt());
     }

--- a/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
@@ -21,29 +21,25 @@ import java.util.List;
 
 
 @RestController
-@RequestMapping("/api/data")
+@RequestMapping("/schemes")
 
 public class DataController {
 
     @Autowired
     private XmlService xmlService;
-  
 
     @GetMapping
     public List<XmlObject> xmlSchema() throws JAXBException {
-        List<XmlObject> result = new ArrayList<XmlObject>();
+        List<XmlObject> result = new ArrayList<>();
         result.add(xmlService.getData(XmlResource.xmldata1));
         result.add(xmlService.getData(XmlResource.xmldata2));
         result.add(xmlService.getData(XmlResource.xmldata3));
+
         return result;
     }
 
-  
-     @PostMapping
-    public void uploadFile(@RequestParam("file") MultipartFile file ) throws IllegalStateException, IOException{
+    @PostMapping
+    public void uploadFile(@RequestParam("file") MultipartFile file) throws IllegalStateException, IOException {
         xmlService.uploadFile(file);
-      
     }
-
-
 }

--- a/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 
 @RestController
-@RequestMapping("/schemes")
+@RequestMapping("/schemas")
 
 public class DataController {
 

--- a/Backend/microservices/data/src/main/resources/application.yml
+++ b/Backend/microservices/data/src/main/resources/application.yml
@@ -6,6 +6,12 @@ eureka:
   service-url:
   default-zone: http://localhost:8761/eureka
 
+routes:
+  microservices:
+    authority:
+      root: http://localhost:8090
+      jwks: ${routes.microservices.authority.root}/.well-known/jwks.json
+
 spring:
   application:
     name: data
@@ -13,4 +19,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://localhost:8090/.well-known/jwks.json
+          jwk-set-uri: ${routes.microservices.authority.jwks}

--- a/Backend/microservices/search/README.MD
+++ b/Backend/microservices/search/README.MD
@@ -2,8 +2,8 @@
 
 ##How to work with:
 1) You must have valid token in header
-2) Get schemas from Data API: http://localhost:8082/api/search
-3) Post to get data from Connector API: http://localhost:8082/api/search in body you should have json like this:
+2) Get schemas from Data API: http://localhost:8082/search
+3) Post to get data from Connector API: http://localhost:8082/search in body you should have json like this:
 ```json
 {
  "firstName": "Sherlock",

--- a/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/ConnectorConnect.java
+++ b/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/ConnectorConnect.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 @FeignClient(name="connector")
 public interface ConnectorConnect {
-    @PostMapping("/api/searcher/")
-    public Map<String, Map<String, String>> searcher(@RequestHeader(value = "Authorization", required = true) String authorizationHeader, @RequestBody SearchQuery searchQuery);
+
+    @PostMapping("/searcher")
+    Map<String, Map<String, String>> searcher(@RequestHeader(value = "Authorization", required = true) String authorizationHeader, @RequestBody SearchQuery searchQuery);
 }

--- a/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/DataConnect.java
+++ b/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/DataConnect.java
@@ -8,8 +8,9 @@ import org.springframework.web.bind.annotation.RequestHeader;
 import javax.xml.bind.JAXBException;
 import java.util.List;
 
-@FeignClient(name="data")
+@FeignClient(name = "data")
 public interface DataConnect {
-    @GetMapping("/api/data")
-    public List<XmlObject> xmlSchema(@RequestHeader(value = "Authorization", required = true) String authorizationHeader) throws JAXBException ;
+
+    @GetMapping("/schemes")
+    List<XmlObject> xmlSchema(@RequestHeader(value = "Authorization", required = true) String authorizationHeader) throws JAXBException;
 }

--- a/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/DataConnect.java
+++ b/Backend/microservices/search/src/main/java/com/ms/search/connectInterface/DataConnect.java
@@ -11,6 +11,6 @@ import java.util.List;
 @FeignClient(name = "data")
 public interface DataConnect {
 
-    @GetMapping("/schemes")
+    @GetMapping("/schemas")
     List<XmlObject> xmlSchema(@RequestHeader(value = "Authorization", required = true) String authorizationHeader) throws JAXBException;
 }

--- a/Backend/microservices/search/src/main/java/com/ms/search/controller/SearchController.java
+++ b/Backend/microservices/search/src/main/java/com/ms/search/controller/SearchController.java
@@ -8,7 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/search")
+@RequestMapping("/search")
 public class SearchController {
 
     private final DataConnect dataConnect;

--- a/Backend/microservices/search/src/main/resources/application.yml
+++ b/Backend/microservices/search/src/main/resources/application.yml
@@ -6,6 +6,13 @@ eureka:
     service-url:
       default-zone:
         http://localhost:8761/eureka
+
+routes:
+  microservices:
+    authority:
+      root: http://localhost:8090
+      jwks: ${routes.microservices.authority.root}/.well-known/jwks.json
+
 spring:
   application:
     name: search
@@ -13,4 +20,4 @@ spring:
     oauth2:
       resourceserver:
         jwt:
-          jwk-set-uri: http://localhost:8090/.well-known/jwks.json
+          jwk-set-uri: ${routes.microservices.authority.jwks}


### PR DESCRIPTION
Renamed urls due to our mapping convention:

Auth:
/users/{userId}/enable	=> /users/{userId}/active/{newState}
/users/{userId}/disable => /users/{userId}/active/{newState}

Connector:
/api/searcher 		=> /searcher

Data:
/api/data 		=> /schemas

Search:
/api/search		=> /search

Also changed configuration in application.yml files of microservices to use same jwk-set-uri.
Later we can just specify one environment variable for authority url and every microservice will load jwk from this url.