### PR TITLE
Rename frontend urls due to convention

### DIFF
--- a/Frontend/src/app/app-routing.module.ts
+++ b/Frontend/src/app/app-routing.module.ts
@@ -19,17 +19,17 @@ import {UnauthorizedAuthGuard} from "./shared/auth-guards/unauthorized.auth.guar
 
 const routes: Routes = [
   {path: '', redirectTo: '/login', pathMatch: 'full'},
-  {path: 'admin/allSchemas', component: AdminManageSchemaListComponent, canActivate: [SchemaAdminAuthGuard]},
-  {path: 'admin/allUsers', component: AdminManageUserListComponent, canActivate: [UserAdminAuthGuard]},
+  {path: 'schemas', component: AdminManageSchemaListComponent, canActivate: [SchemaAdminAuthGuard]},
+  {path: 'users', component: AdminManageUserListComponent, canActivate: [UserAdminAuthGuard]},
   {path: "login", component: LoginFormComponent, canActivate: [UnauthorizedAuthGuard]},
   {path: "twoFactor", component: TwoFactorAuthenticationFormComponent, canActivate: [UnauthorizedAuthGuard]},
-  {path: "error403", component: Error403Component},
-  {path: "error404", component: Error404Component},
-  {path: "error500", component: Error500Component},
+  {path: "error-403", component: Error403Component},
+  {path: "error-404", component: Error404Component},
+  {path: "error-500", component: Error500Component},
   {path: "register", component: RegisterComponent, canActivate: [UnauthorizedAuthGuard]},
   {path: "register/:token", component: RegisterComponent, canActivate: [UnauthorizedAuthGuard]},
-  {path: 'userSearch', component: UserSearchInterfaceComponent, canActivate: [UserAuthGuard]},
-  {path: 'searchResponse', component: SearchResponseComponent},
+  {path: 'search', component: UserSearchInterfaceComponent, canActivate: [UserAuthGuard]},
+  {path: 'search/response', component: SearchResponseComponent},
   {path:'**',component:Error404Component}
 ];
 

--- a/Frontend/src/app/errorpages/error403/error403.component.ts
+++ b/Frontend/src/app/errorpages/error403/error403.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-error403',
+  selector: 'app-error-403',
   templateUrl: './error403.component.html',
   styleUrls: ['./error403.component.css']
 })

--- a/Frontend/src/app/errorpages/error404/error404.component.ts
+++ b/Frontend/src/app/errorpages/error404/error404.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-error404',
+  selector: 'app-error-404',
   templateUrl: './error404.component.html',
   styleUrls: ['./error404.component.css']
 })

--- a/Frontend/src/app/errorpages/error500/error500.component.ts
+++ b/Frontend/src/app/errorpages/error500/error500.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 
 @Component({
-  selector: 'app-error500',
+  selector: 'app-error-500',
   templateUrl: './error500.component.html',
   styleUrls: ['./error500.component.css']
 })

--- a/Frontend/src/app/header/header.component.html
+++ b/Frontend/src/app/header/header.component.html
@@ -8,14 +8,14 @@
     </a>
 
     <div *ngIf="isUserAdmin" class="col-auto">
-      <a routerLink="/admin/allUsers" class="nav-link">
+      <a routerLink="/users" class="nav-link">
         <i class="bi-person-square"></i>
         Manage Users
       </a>
     </div>
 
     <div *ngIf="isSchemaAdmin" class="col-auto">
-      <a routerLink="/admin/allSchemas" class="nav-link">
+      <a routerLink="/schemas" class="nav-link">
         <i class="bi-table"></i>
         Manage Schemas
       </a>

--- a/Frontend/src/app/search-response/search-response.component.html
+++ b/Frontend/src/app/search-response/search-response.component.html
@@ -2,10 +2,10 @@
   <app-header></app-header>
   <div class="row">
     <nav class="nav nav-tabs mt-3 ">
-      <a routerLink="/userSearch" routerLinkActive="active" class="nav-item nav-link">
+      <a routerLink="/search" routerLinkActive="active" class="nav-item nav-link">
         <i class="bi-house-door"></i> Search
       </a>
-      <a routerLink="/searchResponse" routerLinkActive="active" class="nav-item nav-link">
+      <a routerLink="/search/response" routerLinkActive="active" class="nav-item nav-link">
         <i class="bi-person"></i> Search Result
       </a>
     </nav>

--- a/Frontend/src/app/shared/auth.service.ts
+++ b/Frontend/src/app/shared/auth.service.ts
@@ -50,13 +50,13 @@ export class AuthService {
   public getUrlToNavigateAfterLogin(): string {
     switch (true) {
       case this.isUserAdminLoggedIn(): {
-        return 'admin/allUsers';
+        return 'users';
       }
       case this.isSchemaAdminLoggedIn(): {
-        return 'admin/allSchemas';
+        return 'schemas';
       }
       default: {
-        return 'userSearch';
+        return 'search';
       }
     }
   }

--- a/Frontend/src/app/shared/http.client.service.ts
+++ b/Frontend/src/app/shared/http.client.service.ts
@@ -16,23 +16,22 @@ import {RequestResult} from "./data/request-result";
 export class HttpClientService {
 
   private readonly AUTH_SERVER: string = 'http://localhost:8090';
-  private readonly SEARCH_API: string = 'http://localhost:8082';
-  private readonly DATA_API: string = 'http://localhost:8081';
+  private readonly SEARCH_API:  string = 'http://localhost:8082';
+  private readonly DATA_API:    string = 'http://localhost:8081';
 
   // Auth
-  private readonly URL_LOGIN: string = this.AUTH_SERVER + '/oauth/token';
-  private readonly URL_USERS: string = this.AUTH_SERVER + '/users';
-  private readonly URL_ENABLE_USER: string = this.AUTH_SERVER + '/users/{userId}/enable';
-  private readonly URL_DISABLE_USER: string = this.AUTH_SERVER + '/users/{userId}/disable';
-  private readonly URL_ACTIVATION: string = this.AUTH_SERVER + "/users/activation";
-  private readonly URL_REGISTRATION: string = this.AUTH_SERVER + "/users/registration";
+  private readonly URL_LOGIN:           string = this.AUTH_SERVER + '/oauth/token';
+  private readonly URL_USERS:           string = this.AUTH_SERVER + '/users';
+  private readonly URL_SET_USER_ACTIVE: string = this.AUTH_SERVER + '/users/{userId}/active/';
+  private readonly URL_ACTIVATION:      string = this.AUTH_SERVER + "/users/activation";
+  private readonly URL_REGISTRATION:    string = this.AUTH_SERVER + "/users/registration";
 
   // Search API
-  private readonly URL_SCHEMAS: string = this.SEARCH_API + '/api/search';
-  private readonly URL_SEARCH: string = this.SEARCH_API + '/api/search';
+  private readonly URL_SCHEMAS: string = this.SEARCH_API + '/search';
+  private readonly URL_SEARCH:  string = this.SEARCH_API + '/search';
 
   // Data API
-  private readonly URL_DATA: string = this.DATA_API + '/api/data';
+  private readonly URL_DATA: string = this.DATA_API + '/schemas';
 
 
   constructor(private router: Router, private http: HttpClient, private injector: Injector) {
@@ -114,7 +113,7 @@ export class HttpClientService {
 
   public setUserActive(userId: number, isActive: boolean): Observable<any> {
     return this.postRequest(
-      (isActive ? this.URL_ENABLE_USER : this.URL_DISABLE_USER).replace("{userId}", String(userId)),
+      this.URL_SET_USER_ACTIVE.replace("{userId}", String(userId)) + isActive,
       {}
     );
   }

--- a/Frontend/src/app/sidebar/sidebar.component.html
+++ b/Frontend/src/app/sidebar/sidebar.component.html
@@ -9,19 +9,19 @@
       <hr>
       <ul class="nav nav-pills flex-column mb-auto">
         <li>
-          <a routerLink="/admin/allUsers" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isUserAdmin}">
+          <a routerLink="/users" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isUserAdmin}">
             <i class="bi-person-square me-2"></i>
             Manage Users
           </a>
         </li>
         <li>
-          <a routerLink="/admin/allSchemas" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isSchemaAdmin}">
+          <a routerLink="/schemas" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isSchemaAdmin}">
             <i class="bi-table me-2"></i>
             Manage Schemas
           </a>
         </li>
         <li>
-          <a routerLink="/userSearch" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isUser}">
+          <a routerLink="/search" class="nav-link text-white" [ngClass]="{'disabled text-muted': !isUser}">
             <i class="bi bi-search me-2"></i>
             User search
           </a>

--- a/Frontend/src/app/user-search-interface/user-search-interface.component.html
+++ b/Frontend/src/app/user-search-interface/user-search-interface.component.html
@@ -2,10 +2,10 @@
   <app-header></app-header>
   <div class="row">
     <nav class="nav nav-tabs mt-3">
-      <a routerLink="/userSearch" routerLinkActive="active" class="nav-item nav-link">
+      <a routerLink="/search" routerLinkActive="active" class="nav-item nav-link">
         <i class="bi-house-door"></i> Search
       </a>
-      <a routerLink="/searchResponse" routerLinkActive="active" class="nav-item nav-link">
+      <a routerLink="/search/response" routerLinkActive="active" class="nav-item nav-link">
         <i class="bi-person"></i> Search Result
       </a>
     </nav>


### PR DESCRIPTION
Renamed urls on frontend due to our convention:

Frontend:
/admin/allUsers		=> /users
/admin/allSchemas	=> /schemas

/error403		=> /error-403
/error404		=> /error-404
/error500		=> /error-500

/userSearch		=> /search
/searchResponse	=> /search/response