### PR TITLE
Added select schema endpoint

### DIFF
--- a/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/config/JWTSecurityConfigData.java
@@ -10,7 +10,8 @@ public class JWTSecurityConfigData extends WebSecurityConfigurerAdapter {
     @Override
     protected void configure(HttpSecurity http) throws Exception {
         http.authorizeRequests(authz -> authz
-                        .antMatchers(HttpMethod.GET, "/schemas").hasAnyAuthority("SCOPE_user", "SCOPE_admin_schema")
+                        .antMatchers(HttpMethod.GET, "/schemas/selected")
+                            .hasAnyAuthority("SCOPE_user", "SCOPE_admin_schema")
                         .anyRequest().hasAuthority("SCOPE_admin_schema"))
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt());
     }

--- a/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/controller/DataController.java
@@ -50,6 +50,16 @@ public class DataController {
         }
     }
 
+    @GetMapping("/selected")
+    public InterfaceSchema getSelectedSchema() {
+        return cloudStorageService.getSelectedSchema();
+    }
+
+    @PostMapping("/{name}/select")
+    public void selectSchemaByName(@PathVariable("name") String name) {
+        cloudStorageService.selectSchema(name);
+    }
+
     @PostMapping
     public void uploadSchema(@RequestParam("file") MultipartFile file) {
         cloudStorageService.uploadSchema(file);

--- a/Backend/microservices/data/src/main/java/com/ms/data/dto/SchemaFile.java
+++ b/Backend/microservices/data/src/main/java/com/ms/data/dto/SchemaFile.java
@@ -3,12 +3,14 @@ package com.ms.data.dto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Setter
 @AllArgsConstructor
+@ToString
 public class SchemaFile {
 
     private final String name;


### PR DESCRIPTION
New mappings:

- POST /schemas/{name}/select - make schema with {name} selected, other selected schema become unselected. If schema does not exists or cannot be converted to InterfaceSchema object, throws an exception
- GET /schemas/selected - returns JSON of currently selected schema

/schemas/selected Is accessible with schema admin or user tokens, all other data API mappings accessible only with schema admin token